### PR TITLE
自動リリースノート生成とGitHub Releasesの実装 (#7)

### DIFF
--- a/.github/scripts/post-release.sh
+++ b/.github/scripts/post-release.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+NOTES_FILE="$1"
+if [ ! -f "$NOTES_FILE" ]; then
+  echo "No release notes file: $NOTES_FILE"
+  exit 0
+fi
+NOTES=$(cat "$NOTES_FILE")
+# Shortened text for tweet-like services
+TWEET_TEXT=$(echo "$NOTES" | sed 's/\n/ /g' | cut -c1-270)
+
+# Post to Slack via Incoming Webhook
+if [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
+  echo "Posting to Slack..."
+  payload=$(jq -nc --arg text "${NOTES}" '{text:$text}')
+  curl -s -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL" || echo "Slack post failed"
+else
+  echo "SLACK_WEBHOOK_URL not set; skipping Slack"
+fi
+
+# Post to X (Twitter) via v2 endpoint - requires OAuth2 user context token with write access
+if [ -n "${X_BEARER_TOKEN:-}" ]; then
+  echo "Posting to X..."
+  curl -s -X POST "https://api.twitter.com/2/tweets" \
+    -H "Authorization: Bearer ${X_BEARER_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "{\"text\": \"${TWEET_TEXT//"/\"}\"}" || echo "X post failed"
+else
+  echo "X_BEARER_TOKEN not set; skipping X"
+fi
+
+# Post to Qiita
+if [ -n "${QIITA_TOKEN:-}" ]; then
+  echo "Posting to Qiita..."
+  TITLE="Release - ${GITHUB_RUN_NUMBER:-unknown}"
+  BODY="# Release Notes\n\n${NOTES}"
+  data=$(jq -nc --arg title "$TITLE" --arg body "$BODY" '{title:$title, body:$body, private:false, tags:[] }')
+  curl -s -X POST "https://qiita.com/api/v2/items" \
+    -H "Authorization: Bearer ${QIITA_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$data" || echo "Qiita post failed"
+else
+  echo "QIITA_TOKEN not set; skipping Qiita"
+fi
+
+echo "Done posting (attempted)."

--- a/.github/workflows/release-post.yml
+++ b/.github/workflows/release-post.yml
@@ -1,0 +1,105 @@
+name: Release Notes & Post
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  release_and_post:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: |
+          git fetch --tags --prune
+
+      - name: Determine next version
+        id: version
+        run: |
+          set -e
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "Latest tag: $LATEST_TAG"
+
+          # Extract version numbers
+          VERSION=${LATEST_TAG#v}
+          MAJOR=$(echo $VERSION | cut -d. -f1)
+          MINOR=$(echo $VERSION | cut -d. -f2)
+          PATCH=$(echo $VERSION | cut -d. -f3)
+
+          # Increment patch version
+          PATCH=$((PATCH + 1))
+          NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+
+          echo "New version: $NEW_VERSION"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          set -e
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+          if [ -n "$LATEST_TAG" ]; then
+            echo "Found latest tag: $LATEST_TAG"
+            git log ${LATEST_TAG}..HEAD --pretty=format:"- %s (%h)" > release-notes.md || true
+          else
+            echo "No tags found, using full history"
+            git log --pretty=format:"- %s (%h)" > release-notes.md || true
+          fi
+
+          # Add header with version
+          echo "# Release ${{ steps.version.outputs.version }}" > temp-notes.md
+          echo "" >> temp-notes.md
+          echo "## Changes" >> temp-notes.md
+          cat release-notes.md >> temp-notes.md
+          mv temp-notes.md release-notes.md
+
+          echo "Generated release-notes.md"
+
+      - name: Show release notes
+        run: |
+          echo '--- Release Notes ---'
+          if [ -f release-notes.md ]; then cat release-notes.md; else echo '(no release notes)'; fi
+          echo '---------------------'
+
+      - name: Create Git Tag
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.version }}"
+
+      - name: Create GitHub Release
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.version }}" \
+            --title "Release ${{ steps.version.outputs.version }}" \
+            --notes-file release-notes.md
+
+      - name: Install dependencies for SNS posting
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y jq curl
+
+      - name: Post release notes to SNS (Slack / X / Qiita)
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          X_BEARER_TOKEN: ${{ secrets.X_BEARER_TOKEN }}
+          QIITA_TOKEN: ${{ secrets.QIITA_TOKEN }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          chmod +x .github/scripts/post-release.sh
+          .github/scripts/post-release.sh release-notes.md


### PR DESCRIPTION
## Summary
- セマンティックバージョニングによる自動タグ作成機能の実装
- GitHub Releasesへのリリースノート自動投稿機能の実装
- Slack/X/Qiitaへの自動投稿機能の実装

## Changes
- `.github/workflows/release-post.yml`を拡張
  - 最新タグからパッチバージョンを自動インクリメント
  - mainブランチへのpush時に自動的にGitタグを作成
  - GitHub Releasesを自動作成してリリースノートを投稿
  - コミット履歴から変更内容を自動抽出
- `.github/scripts/post-release.sh`を追加
  - Slack Webhook経由での投稿
  - X (Twitter) API v2での投稿
  - Qiita APIでの記事投稿

## 動作フロー
1. mainブランチへのpushをトリガーに起動
2. 最新タグから次のバージョン番号を計算（v0.0.1から開始）
3. コミット履歴からMarkdown形式のリリースノートを生成
4. Gitタグを作成してリモートにpush
5. GitHub Releaseを作成
6. Slack/X/Qiitaに投稿（各シークレットが設定されている場合）

## Test plan
- [x] ワークフローファイルの構文確認
- [x] コミット履歴の確認
- [ ] mainブランチへのマージ後、自動リリース作成を確認
- [ ] Slack投稿の確認（SLACK_WEBHOOK_URL設定済み）
- [ ] GitHub Releasesページでリリースノート確認

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)