### PR TITLE
refactor: #89 Demoサービスの認知コスト削減リファクタリング

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -1,6 +1,51 @@
 # Claude AI Development Instructions
 
-**プロジェクトの開発規約は [.github/copilot-instructions.md](.github/copilot-instructions.md) を参照してください。**
+**コードの生成・修正・Issue作成など、いかなる作業を開始する前に、必ず最初に `.github/copilot-instructions.md` を Read ツールで読んでください。読まずに作業を開始することは禁止です。**
 
-このファイルに記載されている内容を必ず遵守してください。
+読んだ上で、記載されている内容を必ず遵守してください。
 
+## コード生成時の必須手順
+
+コードを生成・修正する前に以下を必ず実行してください。
+
+1. `.github/copilot-instructions.md` を読む
+2. 以下の規約に従ってコードを生成する
+
+## 必須: XMLドキュメントコメント
+
+すべての `public` クラス・メソッドに以下を記載してください。
+
+```csharp
+/// <summary>
+/// [概要]
+/// </summary>
+/// <remarks>
+/// <para><strong>設計書:</strong> .github/docs/features/[機能名]/internal-design.md</para>
+/// <para><strong>責務:</strong> [責務の説明]</para>
+/// <para><strong>アルゴリズム:</strong></para>
+/// <list type="number">
+/// <item><description>[手順1]</description></item>
+/// <item><description>[手順2]</description></item>
+/// </list>
+/// </remarks>
+```
+
+DBアクセスがある場合は必ずSQL文を `<code>` で記載してください。
+
+## 必須: 定数・マジックナンバー
+
+数値や文字列のハードコードは禁止です。必ず名前付き定数にしてください。
+
+```csharp
+// NG
+const int batchSize = 500;
+
+// OK
+/// <summary>SQLiteの1回のINSERTで扱える最大行数</summary>
+private const int BatchSize = 500;
+```
+
+## 必須: 設計書との同期
+
+- コード修正後は必ず `.github/docs/features/[機能名]/` の設計書を更新する
+- 技術判断が必要な変更は `.github/docs/adr/` にADRを作成する

--- a/src/BlazorApp/Features/Demo/FullScan/DTOs/FullScanResponse.cs
+++ b/src/BlazorApp/Features/Demo/FullScan/DTOs/FullScanResponse.cs
@@ -1,25 +1,49 @@
 namespace BlazorApp.Features.Demo.DTOs;
 
+/// <summary>フルスキャンデモの検索結果DTO</summary>
 public class FullScanResponse
 {
+    /// <summary>クエリの実行時間（ミリ秒）</summary>
     public long ExecutionTimeMs { get; set; }
+
+    /// <summary>ヒットした件数</summary>
     public int RowCount { get; set; }
+
+    /// <summary>インデックスが使用されたかどうか</summary>
     public bool HasIndex { get; set; }
+
+    /// <summary>結果メッセージ（実行計画・インデックス有無の説明）</summary>
     public string Message { get; set; } = string.Empty;
+
+    /// <summary>検索結果データ（先頭数件）</summary>
     public List<LargeUserInfo> Data { get; set; } = new();
 }
 
+/// <summary>フルスキャンデモ用ユーザー情報DTO</summary>
 public class LargeUserInfo
 {
+    /// <summary>ユーザーID</summary>
     public int Id { get; set; }
+
+    /// <summary>メールアドレス（インデックス対象カラム）</summary>
     public string Email { get; set; } = string.Empty;
+
+    /// <summary>ユーザー名</summary>
     public string Name { get; set; } = string.Empty;
 }
 
+/// <summary>テストデータセットアップ結果DTO（全デモ共通）</summary>
 public class SetupResponse
 {
+    /// <summary>セットアップが成功したかどうか</summary>
     public bool Success { get; set; }
+
+    /// <summary>挿入または既存のデータ件数</summary>
     public int RowCount { get; set; }
+
+    /// <summary>処理時間（ミリ秒）</summary>
     public long ExecutionTimeMs { get; set; }
+
+    /// <summary>結果メッセージ</summary>
     public string Message { get; set; } = string.Empty;
 }

--- a/src/BlazorApp/Features/Demo/FullScan/FullScanController.cs
+++ b/src/BlazorApp/Features/Demo/FullScan/FullScanController.cs
@@ -3,24 +3,49 @@ using BlazorApp.Features.Demo.Services;
 
 namespace BlazorApp.Features.Demo.FullScan;
 
+/// <summary>
+/// フルスキャンデモ（インデックスの有無による検索速度比較）のコントローラー
+/// </summary>
+/// <remarks>
+/// <para><strong>設計書:</strong> .github/docs/features/full-scan-demo/internal-design.md</para>
+/// <para><strong>責務:</strong> インデックスなし・インデックスあり検索のAPIエンドポイントを提供し、実行時間を比較する</para>
+/// <para><strong>エンドポイント一覧:</strong></para>
+/// <list type="bullet">
+/// <item><description>GET  /Demo/FullScan              - デモ画面表示</description></item>
+/// <item><description>POST /api/demo/full-scan/setup   - テストデータ生成</description></item>
+/// <item><description>GET  /api/demo/full-scan/without-index - インデックスなし検索</description></item>
+/// <item><description>POST /api/demo/full-scan/create-index  - インデックス作成</description></item>
+/// <item><description>GET  /api/demo/full-scan/with-index    - インデックスあり検索</description></item>
+/// </list>
+/// </remarks>
 [Route("Demo")]
 public class FullScanController : Controller
 {
     private readonly IFullScanService _fullScanService;
     private readonly ILogger<FullScanController> _logger;
 
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    /// <param name="fullScanService">フルスキャンデモサービス</param>
+    /// <param name="logger">ロガー</param>
     public FullScanController(IFullScanService fullScanService, ILogger<FullScanController> logger)
     {
         _fullScanService = fullScanService;
         _logger = logger;
     }
 
+    /// <summary>デモ画面を表示する</summary>
     [Route("FullScan")]
     public IActionResult FullScan()
     {
         return View("~/Features/Demo/FullScan/Views/FullScan.cshtml");
     }
 
+    /// <summary>
+    /// テストデータをセットアップする
+    /// </summary>
+    /// <returns>セットアップ結果（行数・処理時間）</returns>
     [HttpPost("/api/demo/full-scan/setup")]
     public async Task<IActionResult> FullScanSetup()
     {
@@ -36,6 +61,11 @@ public class FullScanController : Controller
         }
     }
 
+    /// <summary>
+    /// インデックスなしでEmailを検索する（フルスキャン）
+    /// </summary>
+    /// <param name="email">検索するメールアドレス（前方一致）</param>
+    /// <returns>検索結果（ヒット件数・処理時間・実行計画）</returns>
     [HttpGet("/api/demo/full-scan/without-index")]
     public async Task<IActionResult> FullScanWithoutIndex([FromQuery] string? email)
     {
@@ -54,6 +84,10 @@ public class FullScanController : Controller
         }
     }
 
+    /// <summary>
+    /// Emailカラムにインデックスを作成する
+    /// </summary>
+    /// <returns>作成結果（処理時間）</returns>
     [HttpPost("/api/demo/full-scan/create-index")]
     public async Task<IActionResult> FullScanCreateIndex()
     {
@@ -69,6 +103,11 @@ public class FullScanController : Controller
         }
     }
 
+    /// <summary>
+    /// インデックスありでEmailを検索する（インデックスを使用）
+    /// </summary>
+    /// <param name="email">検索するメールアドレス（前方一致）</param>
+    /// <returns>検索結果（ヒット件数・処理時間・実行計画）</returns>
     [HttpGet("/api/demo/full-scan/with-index")]
     public async Task<IActionResult> FullScanWithIndex([FromQuery] string? email)
     {

--- a/src/BlazorApp/Features/Demo/FullScan/Services/FullScanService.cs
+++ b/src/BlazorApp/Features/Demo/FullScan/Services/FullScanService.cs
@@ -5,12 +5,35 @@ using BlazorApp.Features.Demo.DTOs;
 
 namespace BlazorApp.Features.Demo.Services;
 
+/// <summary>
+/// フルスキャンデモのサービス実装
+/// </summary>
+/// <remarks>
+/// <para><strong>設計書:</strong> .github/docs/features/FullScan/internal-design.md</para>
+/// <para><strong>責務:</strong> SQLiteを使ってインデックスあり/なしの検索パフォーマンス差を実測する</para>
+/// <para><strong>依存関係:</strong></para>
+/// <list type="bullet">
+/// <item><description>IConfiguration: 接続文字列（FullScanDemo）取得</description></item>
+/// <item><description>ILogger: 実行時間・件数のログ出力</description></item>
+/// </list>
+/// </remarks>
 public class FullScanService : IFullScanService
 {
+    /// <summary>SQLiteへの1回のINSERTで扱う行数。SQLiteのパラメータ上限(999)を考慮した値</summary>
+    private const int BatchSize = 500;
+
     private readonly IConfiguration _configuration;
     private readonly ILogger<FullScanService> _logger;
+
+    /// <summary>セットアップ時に生成するデータ件数。デフォルトは100万件</summary>
     private readonly int _totalRows;
 
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    /// <param name="configuration">接続文字列を含む設定</param>
+    /// <param name="logger">ロガー</param>
+    /// <param name="totalRows">生成するデータ件数（テスト時に小さい値を渡せるよう引数化）</param>
     public FullScanService(IConfiguration configuration, ILogger<FullScanService> logger, int totalRows = 1_000_000)
     {
         _configuration = configuration;
@@ -18,25 +41,29 @@ public class FullScanService : IFullScanService
         _totalRows = totalRows;
     }
 
-    private SqliteConnection GetConnection()
-    {
-        var connectionString = _configuration.GetConnectionString("FullScanDemo");
-        return new SqliteConnection(connectionString);
-    }
-
-    private async Task EnsureTableCreatedAsync(SqliteConnection connection)
-    {
-        var cmd = connection.CreateCommand();
-        cmd.CommandText = @"
-            CREATE TABLE IF NOT EXISTS LargeUsers (
-                Id INTEGER PRIMARY KEY AUTOINCREMENT,
-                Email TEXT NOT NULL,
-                Name TEXT NOT NULL,
-                CreatedAt TEXT DEFAULT (datetime('now'))
-            );";
-        await cmd.ExecuteNonQueryAsync();
-    }
-
+    /// <summary>
+    /// デモ用データ（デフォルト100万件）をセットアップする
+    /// </summary>
+    /// <returns>セットアップ結果（件数・処理時間）</returns>
+    /// <remarks>
+    /// <para><strong>アルゴリズム:</strong></para>
+    /// <list type="number">
+    /// <item><description>テーブル未作成の場合は作成（CREATE TABLE IF NOT EXISTS）</description></item>
+    /// <item><description>既存データがある場合はスキップして早期リターン</description></item>
+    /// <item><description>500件ずつバッチINSERTでデータを生成（トランザクションで一括コミット）</description></item>
+    /// </list>
+    /// <para><strong>SQL文:</strong></para>
+    /// <code>
+    /// CREATE TABLE IF NOT EXISTS LargeUsers (
+    ///     Id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ///     Email TEXT NOT NULL,
+    ///     Name TEXT NOT NULL,
+    ///     CreatedAt TEXT DEFAULT (datetime('now'))
+    /// );
+    /// INSERT INTO LargeUsers (Email, Name) VALUES (...), (...), ...;
+    /// </code>
+    /// <para><strong>期待実行時間:</strong> 約30〜60秒（100万件・初回のみ）</para>
+    /// </remarks>
     public async Task<SetupResponse> SetupAsync()
     {
         var sw = Stopwatch.StartNew();
@@ -45,9 +72,7 @@ public class FullScanService : IFullScanService
         await connection.OpenAsync();
         await EnsureTableCreatedAsync(connection);
 
-        var countCmd = connection.CreateCommand();
-        countCmd.CommandText = "SELECT COUNT(*) FROM LargeUsers";
-        var existing = Convert.ToInt32(await countCmd.ExecuteScalarAsync());
+        var existing = await CountExistingRowsAsync(connection);
         if (existing > 0)
         {
             sw.Stop();
@@ -60,27 +85,7 @@ public class FullScanService : IFullScanService
             };
         }
 
-        const int batchSize = 500;
-
-        var lastNames = new[] { "田中", "鈴木", "佐藤", "高橋", "伊藤", "渡辺", "山本", "中村", "小林", "加藤" };
-        var firstNames = new[] { "太郎", "花子", "次郎", "美咲", "健一", "恵子", "大輔", "裕子", "隆", "由美" };
-
-        using var transaction = connection.BeginTransaction();
-        for (int batch = 0; batch < _totalRows / batchSize; batch++)
-        {
-            var values = new StringBuilder();
-            for (int i = 0; i < batchSize; i++)
-            {
-                var rowNum = batch * batchSize + i + 1;
-                var name = lastNames[rowNum % lastNames.Length] + firstNames[rowNum % firstNames.Length];
-                if (i > 0) values.Append(',');
-                values.Append($"('user{rowNum:D7}@example.com', '{name}')");
-            }
-            var insertCmd = connection.CreateCommand();
-            insertCmd.CommandText = $"INSERT INTO LargeUsers (Email, Name) VALUES {values}";
-            await insertCmd.ExecuteNonQueryAsync();
-        }
-        transaction.Commit();
+        await InsertBatchDataAsync(connection);
 
         sw.Stop();
         _logger.LogInformation("FullScan setup completed: {RowCount} rows, {ExecutionTimeMs}ms", _totalRows, sw.ElapsedMilliseconds);
@@ -94,6 +99,19 @@ public class FullScanService : IFullScanService
         };
     }
 
+    /// <summary>
+    /// インデックスなしでメールアドレスを検索する（フルスキャン）
+    /// </summary>
+    /// <param name="email">検索するメールアドレス</param>
+    /// <returns>検索結果（件数・処理時間・HasIndex=false）</returns>
+    /// <remarks>
+    /// <para><strong>アルゴリズム:</strong> インデックスなしで全件スキャンしてEmailを比較する</para>
+    /// <para><strong>SQL文:</strong></para>
+    /// <code>
+    /// SELECT Id, Email, Name FROM LargeUsers WHERE Email = @email
+    /// </code>
+    /// <para><strong>期待実行時間:</strong> 約200〜800ms（インデックスなしでフルスキャン）</para>
+    /// </remarks>
     public async Task<FullScanResponse> SearchWithoutIndexAsync(string email)
     {
         var sw = Stopwatch.StartNew();
@@ -130,6 +148,17 @@ public class FullScanService : IFullScanService
         };
     }
 
+    /// <summary>
+    /// Email列にインデックスを作成する
+    /// </summary>
+    /// <returns>インデックス作成結果（処理時間）</returns>
+    /// <remarks>
+    /// <para><strong>SQL文:</strong></para>
+    /// <code>
+    /// CREATE INDEX IF NOT EXISTS IX_LargeUsers_Email ON LargeUsers(Email)
+    /// </code>
+    /// <para><strong>期待実行時間:</strong> 約5〜15秒（100万件に対してインデックス構築）</para>
+    /// </remarks>
     public async Task<SetupResponse> CreateIndexAsync()
     {
         var sw = Stopwatch.StartNew();
@@ -152,6 +181,19 @@ public class FullScanService : IFullScanService
         };
     }
 
+    /// <summary>
+    /// インデックスありでメールアドレスを検索する
+    /// </summary>
+    /// <param name="email">検索するメールアドレス</param>
+    /// <returns>検索結果（件数・処理時間・HasIndex=true）</returns>
+    /// <remarks>
+    /// <para><strong>アルゴリズム:</strong> IX_LargeUsers_Email インデックスを使ってB-Treeで高速検索する</para>
+    /// <para><strong>SQL文:</strong></para>
+    /// <code>
+    /// SELECT Id, Email, Name FROM LargeUsers WHERE Email = @email
+    /// </code>
+    /// <para><strong>期待実行時間:</strong> 約1〜5ms（インデックスによりO(log n)で検索）</para>
+    /// </remarks>
     public async Task<FullScanResponse> SearchWithIndexAsync(string email)
     {
         var sw = Stopwatch.StartNew();
@@ -186,5 +228,64 @@ public class FullScanService : IFullScanService
             Data = result,
             Message = $"インデックスあり: インデックスを使って高速に取得しました（{sw.ElapsedMilliseconds}ms）"
         };
+    }
+
+    /// <summary>接続文字列からSQLite接続を生成する</summary>
+    private SqliteConnection GetConnection()
+    {
+        var connectionString = _configuration.GetConnectionString("FullScanDemo");
+        return new SqliteConnection(connectionString);
+    }
+
+    /// <summary>LargeUsersテーブルが存在しない場合に作成する</summary>
+    private static async Task EnsureTableCreatedAsync(SqliteConnection connection)
+    {
+        var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+            CREATE TABLE IF NOT EXISTS LargeUsers (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                Email TEXT NOT NULL,
+                Name TEXT NOT NULL,
+                CreatedAt TEXT DEFAULT (datetime('now'))
+            );";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>LargeUsersテーブルの現在の行数を返す</summary>
+    private static async Task<int> CountExistingRowsAsync(SqliteConnection connection)
+    {
+        var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM LargeUsers";
+        return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+    }
+
+    /// <summary>
+    /// 日本語名のダミーデータをバッチINSERTで生成する
+    /// </summary>
+    /// <remarks>
+    /// BatchSize件ずつINSERTしトランザクションで一括コミットすることで
+    /// 単件INSERTに比べて大幅にパフォーマンスを改善している
+    /// </remarks>
+    private async Task InsertBatchDataAsync(SqliteConnection connection)
+    {
+        var lastNames = new[] { "田中", "鈴木", "佐藤", "高橋", "伊藤", "渡辺", "山本", "中村", "小林", "加藤" };
+        var firstNames = new[] { "太郎", "花子", "次郎", "美咲", "健一", "恵子", "大輔", "裕子", "隆", "由美" };
+
+        using var transaction = connection.BeginTransaction();
+        for (int batch = 0; batch < _totalRows / BatchSize; batch++)
+        {
+            var values = new StringBuilder();
+            for (int i = 0; i < BatchSize; i++)
+            {
+                var rowNum = batch * BatchSize + i + 1;
+                var name = lastNames[rowNum % lastNames.Length] + firstNames[rowNum % firstNames.Length];
+                if (i > 0) values.Append(',');
+                values.Append($"('user{rowNum:D7}@example.com', '{name}')");
+            }
+            var insertCmd = connection.CreateCommand();
+            insertCmd.CommandText = $"INSERT INTO LargeUsers (Email, Name) VALUES {values}";
+            await insertCmd.ExecuteNonQueryAsync();
+        }
+        transaction.Commit();
     }
 }

--- a/src/BlazorApp/Features/Demo/FullScan/Services/IFullScanService.cs
+++ b/src/BlazorApp/Features/Demo/FullScan/Services/IFullScanService.cs
@@ -2,10 +2,26 @@ using BlazorApp.Features.Demo.DTOs;
 
 namespace BlazorApp.Features.Demo.Services;
 
+/// <summary>
+/// フルスキャンデモのサービスインターフェース
+/// </summary>
+/// <remarks>
+/// <para><strong>設計書:</strong> .github/docs/features/FullScan/internal-design.md</para>
+/// <para><strong>責務:</strong> インデックスあり/なしの検索パフォーマンス差を計測・比較する</para>
+/// </remarks>
 public interface IFullScanService
 {
+    /// <summary>デモ用データ（100万件）をセットアップする</summary>
     Task<SetupResponse> SetupAsync();
+
+    /// <summary>インデックスなしでメールアドレスを検索する（フルスキャン）</summary>
+    /// <param name="email">検索するメールアドレス</param>
     Task<FullScanResponse> SearchWithoutIndexAsync(string email);
+
+    /// <summary>Email列にインデックスを作成する</summary>
     Task<SetupResponse> CreateIndexAsync();
+
+    /// <summary>インデックスありでメールアドレスを検索する（インデックス使用）</summary>
+    /// <param name="email">検索するメールアドレス</param>
     Task<FullScanResponse> SearchWithIndexAsync(string email);
 }

--- a/src/BlazorApp/Features/Demo/LikeSearch/DTOs/LikeSearchResponse.cs
+++ b/src/BlazorApp/Features/Demo/LikeSearch/DTOs/LikeSearchResponse.cs
@@ -1,20 +1,42 @@
 namespace BlazorApp.Features.Demo.DTOs;
 
+/// <summary>LIKE検索デモの検索結果DTO</summary>
 public class LikeSearchResponse
 {
+    /// <summary>クエリの実行時間（ミリ秒）</summary>
     public long ExecutionTimeMs { get; set; }
+
+    /// <summary>ヒットした件数</summary>
     public int RowCount { get; set; }
+
+    /// <summary>インデックスが使用されたかどうか（前方一致: true / 部分一致: false）</summary>
     public bool UsesIndex { get; set; }
+
+    /// <summary>検索種別（"prefix" / "partial"）</summary>
     public string SearchType { get; set; } = "";
+
+    /// <summary>実行されたSQL文</summary>
     public string Sql { get; set; } = "";
+
+    /// <summary>検索キーワード</summary>
     public string Keyword { get; set; } = "";
+
+    /// <summary>結果メッセージ（インデックス使用有無の説明）</summary>
     public string Message { get; set; } = "";
+
+    /// <summary>検索結果データ（先頭数件）</summary>
     public List<SearchUserInfo> Data { get; set; } = new();
 }
 
+/// <summary>LIKE検索デモ用ユーザー情報DTO</summary>
 public class SearchUserInfo
 {
+    /// <summary>ユーザーID</summary>
     public int Id { get; set; }
+
+    /// <summary>ユーザー名</summary>
     public string Name { get; set; } = "";
+
+    /// <summary>メールアドレス</summary>
     public string Email { get; set; } = "";
 }

--- a/src/BlazorApp/Features/Demo/LikeSearch/LikeSearchController.cs
+++ b/src/BlazorApp/Features/Demo/LikeSearch/LikeSearchController.cs
@@ -3,24 +3,48 @@ using BlazorApp.Features.Demo.Services;
 
 namespace BlazorApp.Features.Demo.LikeSearch;
 
+/// <summary>
+/// LIKE検索デモ（前方一致 vs 部分一致のインデックス効率比較）のコントローラー
+/// </summary>
+/// <remarks>
+/// <para><strong>設計書:</strong> .github/docs/features/like-search-demo/internal-design.md</para>
+/// <para><strong>責務:</strong> LIKE検索の前方一致（インデックス使用可）と部分一致（フルスキャン）のAPIエンドポイントを提供する</para>
+/// <para><strong>エンドポイント一覧:</strong></para>
+/// <list type="bullet">
+/// <item><description>GET  /Demo/LikeSearch             - デモ画面表示</description></item>
+/// <item><description>POST /api/demo/like-search/setup  - テストデータ生成</description></item>
+/// <item><description>GET  /api/demo/like-search/prefix - 前方一致検索（keyword%）</description></item>
+/// <item><description>GET  /api/demo/like-search/partial - 部分一致検索（%keyword%）</description></item>
+/// </list>
+/// </remarks>
 [Route("Demo")]
 public class LikeSearchController : Controller
 {
     private readonly ILikeSearchService _likeSearchService;
     private readonly ILogger<LikeSearchController> _logger;
 
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    /// <param name="likeSearchService">LIKE検索デモサービス</param>
+    /// <param name="logger">ロガー</param>
     public LikeSearchController(ILikeSearchService likeSearchService, ILogger<LikeSearchController> logger)
     {
         _likeSearchService = likeSearchService;
         _logger = logger;
     }
 
+    /// <summary>デモ画面を表示する</summary>
     [Route("LikeSearch")]
     public IActionResult LikeSearch()
     {
         return View("~/Features/Demo/LikeSearch/Views/LikeSearch.cshtml");
     }
 
+    /// <summary>
+    /// テストデータをセットアップする
+    /// </summary>
+    /// <returns>セットアップ結果（行数・処理時間）</returns>
     [HttpPost("/api/demo/like-search/setup")]
     public async Task<IActionResult> LikeSearchSetup()
     {
@@ -36,6 +60,11 @@ public class LikeSearchController : Controller
         }
     }
 
+    /// <summary>
+    /// 前方一致で検索する（keyword%）。インデックスが使用されるため高速
+    /// </summary>
+    /// <param name="keyword">検索キーワード（前方一致）</param>
+    /// <returns>検索結果（ヒット件数・処理時間）</returns>
     [HttpGet("/api/demo/like-search/prefix")]
     public async Task<IActionResult> LikeSearchPrefix([FromQuery] string? keyword)
     {
@@ -54,6 +83,11 @@ public class LikeSearchController : Controller
         }
     }
 
+    /// <summary>
+    /// 部分一致で検索する（%keyword%）。インデックスが使用されないためフルスキャンになる
+    /// </summary>
+    /// <param name="keyword">検索キーワード（部分一致）</param>
+    /// <returns>検索結果（ヒット件数・処理時間）</returns>
     [HttpGet("/api/demo/like-search/partial")]
     public async Task<IActionResult> LikeSearchPartial([FromQuery] string? keyword)
     {

--- a/src/BlazorApp/Features/Demo/LikeSearch/Services/ILikeSearchService.cs
+++ b/src/BlazorApp/Features/Demo/LikeSearch/Services/ILikeSearchService.cs
@@ -2,9 +2,23 @@ using BlazorApp.Features.Demo.DTOs;
 
 namespace BlazorApp.Features.Demo.Services;
 
+/// <summary>
+/// LIKE検索デモのサービスインターフェース
+/// </summary>
+/// <remarks>
+/// <para><strong>設計書:</strong> .github/docs/features/LikeSearch/internal-design.md</para>
+/// <para><strong>責務:</strong> 前方一致（インデックス有効）と中間一致（フルスキャン）のパフォーマンス差を計測・比較する</para>
+/// </remarks>
 public interface ILikeSearchService
 {
+    /// <summary>デモ用データ（デフォルト10万件）をセットアップする</summary>
     Task<SetupResponse> SetupAsync();
+
+    /// <summary>前方一致（LIKE 'keyword%'）で検索する。インデックスが有効になる</summary>
+    /// <param name="keyword">検索キーワード</param>
     Task<LikeSearchResponse> SearchPrefixAsync(string keyword);
+
+    /// <summary>中間一致（LIKE '%keyword%'）で検索する。インデックスが無効になりフルスキャンになる</summary>
+    /// <param name="keyword">検索キーワード</param>
     Task<LikeSearchResponse> SearchPartialAsync(string keyword);
 }

--- a/src/BlazorApp/Features/Demo/LikeSearch/Services/LikeSearchService.cs
+++ b/src/BlazorApp/Features/Demo/LikeSearch/Services/LikeSearchService.cs
@@ -5,12 +5,35 @@ using BlazorApp.Features.Demo.DTOs;
 
 namespace BlazorApp.Features.Demo.Services;
 
+/// <summary>
+/// LIKE検索デモのサービス実装
+/// </summary>
+/// <remarks>
+/// <para><strong>設計書:</strong> .github/docs/features/LikeSearch/internal-design.md</para>
+/// <para><strong>責務:</strong> 前方一致と中間一致のLIKE検索パフォーマンス差をSQLiteで実測する</para>
+/// <para><strong>依存関係:</strong></para>
+/// <list type="bullet">
+/// <item><description>IConfiguration: 接続文字列（LikeSearchDemo）取得</description></item>
+/// <item><description>ILogger: 実行時間・件数のログ出力</description></item>
+/// </list>
+/// </remarks>
 public class LikeSearchService : ILikeSearchService
 {
+    /// <summary>SQLiteの1回のINSERTで扱う行数。SQLiteのパラメータ上限(999)を考慮した値</summary>
+    private const int BatchSize = 500;
+
     private readonly IConfiguration _configuration;
     private readonly ILogger<LikeSearchService> _logger;
+
+    /// <summary>セットアップ時に生成するデータ件数。デフォルトは10万件</summary>
     private readonly int _totalRows;
 
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    /// <param name="configuration">接続文字列を含む設定</param>
+    /// <param name="logger">ロガー</param>
+    /// <param name="totalRows">生成するデータ件数（テスト時に小さい値を渡せるよう引数化）</param>
     public LikeSearchService(IConfiguration configuration, ILogger<LikeSearchService> logger, int totalRows = 100_000)
     {
         _configuration = configuration;
@@ -18,26 +41,29 @@ public class LikeSearchService : ILikeSearchService
         _totalRows = totalRows;
     }
 
-    private SqliteConnection GetConnection()
-    {
-        var connectionString = _configuration.GetConnectionString("LikeSearchDemo");
-        return new SqliteConnection(connectionString);
-    }
-
-    private async Task EnsureTableCreatedAsync(SqliteConnection connection)
-    {
-        var cmd = connection.CreateCommand();
-        cmd.CommandText = @"
-            CREATE TABLE IF NOT EXISTS SearchUsers (
-                Id        INTEGER PRIMARY KEY AUTOINCREMENT,
-                Name      TEXT    NOT NULL,
-                Email     TEXT    NOT NULL,
-                CreatedAt TEXT    NOT NULL DEFAULT (datetime('now'))
-            );
-            CREATE INDEX IF NOT EXISTS IX_SearchUsers_Name ON SearchUsers(Name);";
-        await cmd.ExecuteNonQueryAsync();
-    }
-
+    /// <summary>
+    /// デモ用データ（デフォルト10万件）をセットアップする
+    /// </summary>
+    /// <returns>セットアップ結果（件数・処理時間）</returns>
+    /// <remarks>
+    /// <para><strong>アルゴリズム:</strong></para>
+    /// <list type="number">
+    /// <item><description>テーブルとName列インデックスを作成（CREATE TABLE / CREATE INDEX IF NOT EXISTS）</description></item>
+    /// <item><description>既存データがある場合はスキップして早期リターン</description></item>
+    /// <item><description>500件ずつバッチINSERTでデータを生成（トランザクションで一括コミット）</description></item>
+    /// </list>
+    /// <para><strong>SQL文:</strong></para>
+    /// <code>
+    /// CREATE TABLE IF NOT EXISTS SearchUsers (
+    ///     Id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ///     Name TEXT NOT NULL,
+    ///     Email TEXT NOT NULL,
+    ///     CreatedAt TEXT NOT NULL DEFAULT (datetime('now'))
+    /// );
+    /// CREATE INDEX IF NOT EXISTS IX_SearchUsers_Name ON SearchUsers(Name);
+    /// </code>
+    /// <para><strong>期待実行時間:</strong> 約10〜20秒（10万件・初回のみ）</para>
+    /// </remarks>
     public async Task<SetupResponse> SetupAsync()
     {
         var sw = Stopwatch.StartNew();
@@ -61,28 +87,7 @@ public class LikeSearchService : ILikeSearchService
             };
         }
 
-        var lastNames = new[] { "山田", "鈴木", "佐藤", "高橋", "伊藤", "渡辺", "山本", "中村", "小林", "加藤",
-                                 "山口", "山崎", "山下", "川田", "田中", "斎藤", "松本", "井上", "木村", "林" };
-        var firstNames = new[] { "太郎", "花子", "次郎", "美咲", "健一", "恵子", "大輔", "裕子", "隆", "由美",
-                                  "一郎", "幸子", "浩二", "洋子", "明", "直子", "誠", "智子", "豊", "節子" };
-
-        const int batchSize = 500;
-        using var transaction = connection.BeginTransaction();
-        for (int batch = 0; batch < _totalRows / batchSize; batch++)
-        {
-            var values = new StringBuilder();
-            for (int i = 0; i < batchSize; i++)
-            {
-                var rowNum = batch * batchSize + i + 1;
-                var name = lastNames[rowNum % lastNames.Length] + firstNames[rowNum % firstNames.Length];
-                if (i > 0) values.Append(',');
-                values.Append($"('{name}', 'user{rowNum}@example.com')");
-            }
-            var insertCmd = connection.CreateCommand();
-            insertCmd.CommandText = $"INSERT INTO SearchUsers (Name, Email) VALUES {values}";
-            await insertCmd.ExecuteNonQueryAsync();
-        }
-        transaction.Commit();
+        await InsertBatchDataAsync(connection);
 
         sw.Stop();
         _logger.LogInformation("LikeSearch setup completed: {RowCount} rows, {ExecutionTimeMs}ms", _totalRows, sw.ElapsedMilliseconds);
@@ -96,10 +101,25 @@ public class LikeSearchService : ILikeSearchService
         };
     }
 
+    /// <summary>
+    /// 前方一致（LIKE 'keyword%'）で検索する
+    /// </summary>
+    /// <param name="keyword">検索キーワード</param>
+    /// <returns>検索結果（件数・処理時間・UsesIndex=true）</returns>
+    /// <remarks>
+    /// <para><strong>アルゴリズム:</strong> IX_SearchUsers_Name インデックスを使ってB-Treeで前方一致検索する</para>
+    /// <para><strong>SQL文:</strong></para>
+    /// <code>
+    /// SELECT Id, Name, Email FROM SearchUsers WHERE Name LIKE @keyword  -- @keyword = 'keyword%'
+    /// </code>
+    /// <para><strong>期待実行時間:</strong> 約1〜10ms（インデックス有効）</para>
+    /// </remarks>
     public async Task<LikeSearchResponse> SearchPrefixAsync(string keyword)
     {
         var sw = Stopwatch.StartNew();
         var result = new List<SearchUserInfo>();
+
+        // 前方一致パターン: インデックスが有効になる
         var pattern = keyword + "%";
 
         using var connection = GetConnection();
@@ -136,10 +156,25 @@ public class LikeSearchService : ILikeSearchService
         };
     }
 
+    /// <summary>
+    /// 中間一致（LIKE '%keyword%'）で検索する
+    /// </summary>
+    /// <param name="keyword">検索キーワード</param>
+    /// <returns>検索結果（件数・処理時間・UsesIndex=false）</returns>
+    /// <remarks>
+    /// <para><strong>アルゴリズム:</strong> 先頭が'%'のためインデックスが無効になり全件スキャンする</para>
+    /// <para><strong>SQL文:</strong></para>
+    /// <code>
+    /// SELECT Id, Name, Email FROM SearchUsers WHERE Name LIKE @keyword  -- @keyword = '%keyword%'
+    /// </code>
+    /// <para><strong>期待実行時間:</strong> 約50〜200ms（インデックス無効・フルスキャン）</para>
+    /// </remarks>
     public async Task<LikeSearchResponse> SearchPartialAsync(string keyword)
     {
         var sw = Stopwatch.StartNew();
         var result = new List<SearchUserInfo>();
+
+        // 中間一致パターン: 先頭が'%'のためインデックスが使えずフルスキャンになる
         var pattern = "%" + keyword + "%";
 
         using var connection = GetConnection();
@@ -174,5 +209,59 @@ public class LikeSearchService : ILikeSearchService
             Message = $"中間一致（LIKE '{pattern}'）: インデックス無効・フルスキャンで {sw.ElapsedMilliseconds}ms かかりました",
             Data = result.Take(10).ToList()
         };
+    }
+
+    /// <summary>接続文字列からSQLite接続を生成する</summary>
+    private SqliteConnection GetConnection()
+    {
+        var connectionString = _configuration.GetConnectionString("LikeSearchDemo");
+        return new SqliteConnection(connectionString);
+    }
+
+    /// <summary>SearchUsersテーブルとName列インデックスが存在しない場合に作成する</summary>
+    private static async Task EnsureTableCreatedAsync(SqliteConnection connection)
+    {
+        var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+            CREATE TABLE IF NOT EXISTS SearchUsers (
+                Id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                Name      TEXT    NOT NULL,
+                Email     TEXT    NOT NULL,
+                CreatedAt TEXT    NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE INDEX IF NOT EXISTS IX_SearchUsers_Name ON SearchUsers(Name);";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// 日本語名のダミーデータをバッチINSERTで生成する
+    /// </summary>
+    /// <remarks>
+    /// BatchSize件ずつINSERTしトランザクションで一括コミットすることで
+    /// 単件INSERTに比べて大幅にパフォーマンスを改善している
+    /// </remarks>
+    private async Task InsertBatchDataAsync(SqliteConnection connection)
+    {
+        var lastNames = new[] { "山田", "鈴木", "佐藤", "高橋", "伊藤", "渡辺", "山本", "中村", "小林", "加藤",
+                                 "山口", "山崎", "山下", "川田", "田中", "斎藤", "松本", "井上", "木村", "林" };
+        var firstNames = new[] { "太郎", "花子", "次郎", "美咲", "健一", "恵子", "大輔", "裕子", "隆", "由美",
+                                  "一郎", "幸子", "浩二", "洋子", "明", "直子", "誠", "智子", "豊", "節子" };
+
+        using var transaction = connection.BeginTransaction();
+        for (int batch = 0; batch < _totalRows / BatchSize; batch++)
+        {
+            var values = new StringBuilder();
+            for (int i = 0; i < BatchSize; i++)
+            {
+                var rowNum = batch * BatchSize + i + 1;
+                var name = lastNames[rowNum % lastNames.Length] + firstNames[rowNum % firstNames.Length];
+                if (i > 0) values.Append(',');
+                values.Append($"('{name}', 'user{rowNum}@example.com')");
+            }
+            var insertCmd = connection.CreateCommand();
+            insertCmd.CommandText = $"INSERT INTO SearchUsers (Name, Email) VALUES {values}";
+            await insertCmd.ExecuteNonQueryAsync();
+        }
+        transaction.Commit();
     }
 }

--- a/src/BlazorApp/Features/Demo/NPlus/DTOs/NPlusOneResponse.cs
+++ b/src/BlazorApp/Features/Demo/NPlus/DTOs/NPlusOneResponse.cs
@@ -1,24 +1,46 @@
 namespace BlazorApp.Features.Demo.DTOs;
 
+/// <summary>N+1問題デモの検索結果DTO</summary>
 public class NPlusOneResponse
 {
+    /// <summary>処理時間（ミリ秒）</summary>
     public long ExecutionTimeMs { get; set; }
+
+    /// <summary>発行されたSQLクエリの総数（Bad: 1+N, Good: 1）</summary>
     public int SqlCount { get; set; }
+
+    /// <summary>レスポンスのJSONバイト数</summary>
     public int DataSize { get; set; }
+
+    /// <summary>取得したユーザー件数</summary>
     public int RowCount { get; set; }
+
+    /// <summary>検索結果データ（ユーザー＋部署情報）</summary>
     public List<UserWithDepartment> Data { get; set; } = new();
+
+    /// <summary>結果メッセージ（N+1の説明・クエリ数）</summary>
     public string Message { get; set; } = string.Empty;
 }
 
+/// <summary>ユーザー情報と部署情報を結合したDTO</summary>
 public class UserWithDepartment
 {
+    /// <summary>ユーザーID</summary>
     public int Id { get; set; }
+
+    /// <summary>ユーザー名</summary>
     public string Name { get; set; } = string.Empty;
+
+    /// <summary>所属部署</summary>
     public DepartmentInfo Department { get; set; } = new();
 }
 
+/// <summary>部署情報DTO</summary>
 public class DepartmentInfo
 {
+    /// <summary>部署ID</summary>
     public int Id { get; set; }
+
+    /// <summary>部署名</summary>
     public string Name { get; set; } = string.Empty;
 }

--- a/src/BlazorApp/Features/Demo/NPlus/NPlusController.cs
+++ b/src/BlazorApp/Features/Demo/NPlus/NPlusController.cs
@@ -3,24 +3,47 @@ using BlazorApp.Features.Demo.Services;
 
 namespace BlazorApp.Features.Demo.NPlus;
 
+/// <summary>
+/// N+1問題デモ（ループ内クエリ vs JOIN）のコントローラー
+/// </summary>
+/// <remarks>
+/// <para><strong>設計書:</strong> .github/docs/features/n-plus-one-demo/internal-design.md</para>
+/// <para><strong>責務:</strong> N+1問題が発生するBad実装とJOINで解決したGood実装のAPIエンドポイントを提供する</para>
+/// <para><strong>エンドポイント一覧:</strong></para>
+/// <list type="bullet">
+/// <item><description>GET /Demo/Performance          - デモ画面表示</description></item>
+/// <item><description>GET /api/demo/n-plus-one/bad  - N+1問題あり（1+N回クエリ）</description></item>
+/// <item><description>GET /api/demo/n-plus-one/good - N+1問題なし（JOINで1回クエリ）</description></item>
+/// </list>
+/// </remarks>
 [Route("Demo")]
 public class NPlusController : Controller
 {
     private readonly INPlusOneService _nPlusOneService;
     private readonly ILogger<NPlusController> _logger;
 
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    /// <param name="nPlusOneService">N+1問題デモサービス</param>
+    /// <param name="logger">ロガー</param>
     public NPlusController(INPlusOneService nPlusOneService, ILogger<NPlusController> logger)
     {
         _nPlusOneService = nPlusOneService;
         _logger = logger;
     }
 
+    /// <summary>デモ画面を表示する</summary>
     [Route("Performance")]
     public IActionResult Performance()
     {
         return View("~/Features/Demo/NPlus/Views/Performance.cshtml");
     }
 
+    /// <summary>
+    /// N+1問題あり: ループ内で部署情報を個別取得する（1+N回クエリ）
+    /// </summary>
+    /// <returns>ユーザー一覧・発行クエリ数・処理時間</returns>
     [HttpGet("/api/demo/n-plus-one/bad")]
     public async Task<IActionResult> NPlusOneBad()
     {
@@ -36,6 +59,10 @@ public class NPlusController : Controller
         }
     }
 
+    /// <summary>
+    /// N+1問題なし: JOINで1回のクエリにより全データを取得する
+    /// </summary>
+    /// <returns>ユーザー一覧・発行クエリ数=1・処理時間</returns>
     [HttpGet("/api/demo/n-plus-one/good")]
     public async Task<IActionResult> NPlusOneGood()
     {

--- a/src/BlazorApp/Features/Demo/NPlus/Services/INPlusOneService.cs
+++ b/src/BlazorApp/Features/Demo/NPlus/Services/INPlusOneService.cs
@@ -2,8 +2,18 @@ using BlazorApp.Features.Demo.DTOs;
 
 namespace BlazorApp.Features.Demo.Services;
 
+/// <summary>
+/// N+1問題デモのサービスインターフェース
+/// </summary>
+/// <remarks>
+/// <para><strong>設計書:</strong> .github/docs/features/n-plus-one-demo/internal-design.md</para>
+/// <para><strong>責務:</strong> N+1問題が発生するBad実装と、JOINで解決したGood実装を比較する</para>
+/// </remarks>
 public interface INPlusOneService
 {
+    /// <summary>N+1問題あり: ユーザー取得後にループ内で部署情報を個別取得する（1+N回クエリ）</summary>
     Task<NPlusOneResponse> GetUsersBad();
+
+    /// <summary>N+1問題なし: JOINを使って1回のクエリでユーザーと部署情報を一括取得する</summary>
     Task<NPlusOneResponse> GetUsersGood();
 }

--- a/src/BlazorApp/Features/Demo/NPlus/Services/NPlusOneService.cs
+++ b/src/BlazorApp/Features/Demo/NPlus/Services/NPlusOneService.cs
@@ -1,76 +1,60 @@
 using System.Diagnostics;
 using System.Data;
+using System.Text;
 using Microsoft.Data.Sqlite;
 using BlazorApp.Features.Demo.DTOs;
 
 namespace BlazorApp.Features.Demo.Services;
 
+/// <summary>
+/// N+1問題デモのサービス実装
+/// </summary>
+/// <remarks>
+/// <para><strong>設計書:</strong> .github/docs/features/n-plus-one-demo/internal-design.md</para>
+/// <para><strong>責務:</strong> N+1問題が発生するBad実装と、JOINで解決したGood実装を比較する</para>
+/// <para><strong>依存関係:</strong></para>
+/// <list type="bullet">
+/// <item><description>IConfiguration: 接続文字列（NPlusOneDemo）取得</description></item>
+/// <item><description>ILogger: 実行時間・クエリ数のログ出力</description></item>
+/// </list>
+/// </remarks>
 public class NPlusOneService : INPlusOneService
 {
     private readonly IConfiguration _configuration;
     private readonly ILogger<NPlusOneService> _logger;
+
+    /// <summary>現在の処理中に発行したSQLクエリ数。GetUsersBad/GetUsersGood の各呼び出しで0にリセットされる</summary>
     private int _sqlQueryCount;
 
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    /// <param name="configuration">接続文字列を含む設定</param>
+    /// <param name="logger">ロガー</param>
     public NPlusOneService(IConfiguration configuration, ILogger<NPlusOneService> logger)
     {
         _configuration = configuration;
         _logger = logger;
     }
 
-    private SqliteConnection GetConnection()
-    {
-        var connectionString = _configuration.GetConnectionString("NPlusOneDemo");
-        return new SqliteConnection(connectionString);
-    }
-
-    private async Task EnsureDatabaseInitializedAsync(SqliteConnection connection)
-    {
-        var createTables = connection.CreateCommand();
-        createTables.CommandText = @"
-            CREATE TABLE IF NOT EXISTS Departments (
-                Id INTEGER PRIMARY KEY AUTOINCREMENT,
-                Name TEXT NOT NULL,
-                CreatedAt TEXT DEFAULT (datetime('now'))
-            );
-            CREATE TABLE IF NOT EXISTS Users (
-                Id INTEGER PRIMARY KEY AUTOINCREMENT,
-                Name TEXT NOT NULL,
-                DepartmentId INTEGER NOT NULL,
-                Email TEXT NOT NULL,
-                CreatedAt TEXT DEFAULT (datetime('now')),
-                FOREIGN KEY (DepartmentId) REFERENCES Departments(Id)
-            );
-            CREATE INDEX IF NOT EXISTS IX_Users_DepartmentId ON Users(DepartmentId);";
-        await createTables.ExecuteNonQueryAsync();
-
-        var countCmd = connection.CreateCommand();
-        countCmd.CommandText = "SELECT COUNT(*) FROM Departments";
-        var count = Convert.ToInt32(await countCmd.ExecuteScalarAsync());
-        if (count > 0) return;
-
-        var seedDepts = connection.CreateCommand();
-        seedDepts.CommandText = @"
-            INSERT INTO Departments (Name) VALUES
-                ('Engineering'), ('Sales'), ('Marketing'), ('HR'), ('Finance');";
-        await seedDepts.ExecuteNonQueryAsync();
-
-        var lastNames = new[] { "田中", "鈴木", "佐藤", "高橋", "伊藤", "渡辺", "山本", "中村", "小林", "加藤",
-                                "吉田", "山田", "佐々木", "山口", "松本", "井上", "木村", "林", "斎藤", "清水" };
-        var firstNames = new[] { "太郎", "花子", "次郎", "美咲", "健一", "恵子", "大輔", "裕子", "隆", "由美" };
-        var values = new System.Text.StringBuilder();
-        for (int i = 1; i <= 100; i++)
-        {
-            var name = lastNames[(i - 1) % lastNames.Length] + firstNames[(i - 1) % firstNames.Length];
-            var deptId = ((i - 1) % 5) + 1;
-            var email = $"user{i:D3}@example.com";
-            if (i > 1) values.Append(',');
-            values.Append($"('{name}', {deptId}, '{email}')");
-        }
-        var seedUsers = connection.CreateCommand();
-        seedUsers.CommandText = $"INSERT INTO Users (Name, DepartmentId, Email) VALUES {values};";
-        await seedUsers.ExecuteNonQueryAsync();
-    }
-
+    /// <summary>
+    /// N+1問題あり: ユーザー取得後にループ内で部署情報を個別取得する（1+N回クエリ）
+    /// </summary>
+    /// <returns>検索結果（ユーザー一覧・クエリ数・処理時間）</returns>
+    /// <remarks>
+    /// <para><strong>アルゴリズム:</strong></para>
+    /// <list type="number">
+    /// <item><description>USERSを全件取得（1回目のクエリ）</description></item>
+    /// <item><description>各ユーザーに対してDepartmentsを個別取得（N回のクエリ）</description></item>
+    /// <item><description>合計 1+N 回のクエリが発行される</description></item>
+    /// </list>
+    /// <para><strong>SQL文（Bad）:</strong></para>
+    /// <code>
+    /// SELECT Id, Name, DepartmentId, Email FROM Users;           -- 1回
+    /// SELECT Id, Name FROM Departments WHERE Id = @DeptId;       -- N回（ユーザー数分）
+    /// </code>
+    /// <para><strong>期待実行時間:</strong> 約10〜50ms（クエリ数が多いためLatencyが累積）</para>
+    /// </remarks>
     public async Task<NPlusOneResponse> GetUsersBad()
     {
         var sw = Stopwatch.StartNew();
@@ -133,6 +117,7 @@ public class NPlusOneService : INPlusOneService
         }
 
         sw.Stop();
+        _logger.LogInformation("NPlusOne bad: {SqlCount} queries, {RowCount} rows, {ExecutionTimeMs}ms", _sqlQueryCount, result.Count, sw.ElapsedMilliseconds);
 
         return new NPlusOneResponse
         {
@@ -145,6 +130,20 @@ public class NPlusOneService : INPlusOneService
         };
     }
 
+    /// <summary>
+    /// N+1問題なし: JOINを使って1回のクエリでユーザーと部署情報を一括取得する
+    /// </summary>
+    /// <returns>検索結果（ユーザー一覧・クエリ数=1・処理時間）</returns>
+    /// <remarks>
+    /// <para><strong>アルゴリズム:</strong> INNER JOINで1回のクエリにより全データを取得する</para>
+    /// <para><strong>SQL文（Good）:</strong></para>
+    /// <code>
+    /// SELECT u.Id, u.Name, u.Email, d.Id AS DeptId, d.Name AS DeptName
+    /// FROM Users u
+    /// INNER JOIN Departments d ON u.DepartmentId = d.Id
+    /// </code>
+    /// <para><strong>期待実行時間:</strong> 約1〜5ms（1クエリで完結）</para>
+    /// </remarks>
     public async Task<NPlusOneResponse> GetUsersGood()
     {
         var sw = Stopwatch.StartNew();
@@ -185,6 +184,7 @@ public class NPlusOneService : INPlusOneService
         }
 
         sw.Stop();
+        _logger.LogInformation("NPlusOne good: {SqlCount} query, {RowCount} rows, {ExecutionTimeMs}ms", _sqlQueryCount, result.Count, sw.ElapsedMilliseconds);
 
         return new NPlusOneResponse
         {
@@ -195,5 +195,73 @@ public class NPlusOneService : INPlusOneService
             Data = result,
             Message = $"最適化済み: 1回のJOINクエリで全データを取得しています"
         };
+    }
+
+    /// <summary>接続文字列からSQLite接続を生成する</summary>
+    private SqliteConnection GetConnection()
+    {
+        var connectionString = _configuration.GetConnectionString("NPlusOneDemo");
+        return new SqliteConnection(connectionString);
+    }
+
+    /// <summary>
+    /// Departments・Usersテーブルが存在しない場合に作成し、初期データをシードする
+    /// </summary>
+    /// <remarks>
+    /// <para><strong>SQL文:</strong></para>
+    /// <code>
+    /// CREATE TABLE IF NOT EXISTS Departments (Id, Name, CreatedAt);
+    /// CREATE TABLE IF NOT EXISTS Users (Id, Name, DepartmentId, Email, CreatedAt);
+    /// CREATE INDEX IF NOT EXISTS IX_Users_DepartmentId ON Users(DepartmentId);
+    /// INSERT INTO Departments (Name) VALUES ('Engineering'), ('Sales'), ...;  -- 5部署
+    /// INSERT INTO Users (Name, DepartmentId, Email) VALUES ...;               -- 100ユーザー
+    /// </code>
+    /// </remarks>
+    private static async Task EnsureDatabaseInitializedAsync(SqliteConnection connection)
+    {
+        var createTables = connection.CreateCommand();
+        createTables.CommandText = @"
+            CREATE TABLE IF NOT EXISTS Departments (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                Name TEXT NOT NULL,
+                CreatedAt TEXT DEFAULT (datetime('now'))
+            );
+            CREATE TABLE IF NOT EXISTS Users (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                Name TEXT NOT NULL,
+                DepartmentId INTEGER NOT NULL,
+                Email TEXT NOT NULL,
+                CreatedAt TEXT DEFAULT (datetime('now')),
+                FOREIGN KEY (DepartmentId) REFERENCES Departments(Id)
+            );
+            CREATE INDEX IF NOT EXISTS IX_Users_DepartmentId ON Users(DepartmentId);";
+        await createTables.ExecuteNonQueryAsync();
+
+        var countCmd = connection.CreateCommand();
+        countCmd.CommandText = "SELECT COUNT(*) FROM Departments";
+        var count = Convert.ToInt32(await countCmd.ExecuteScalarAsync());
+        if (count > 0) return;
+
+        var seedDepts = connection.CreateCommand();
+        seedDepts.CommandText = @"
+            INSERT INTO Departments (Name) VALUES
+                ('Engineering'), ('Sales'), ('Marketing'), ('HR'), ('Finance');";
+        await seedDepts.ExecuteNonQueryAsync();
+
+        var lastNames = new[] { "田中", "鈴木", "佐藤", "高橋", "伊藤", "渡辺", "山本", "中村", "小林", "加藤",
+                                "吉田", "山田", "佐々木", "山口", "松本", "井上", "木村", "林", "斎藤", "清水" };
+        var firstNames = new[] { "太郎", "花子", "次郎", "美咲", "健一", "恵子", "大輔", "裕子", "隆", "由美" };
+        var values = new StringBuilder();
+        for (int i = 1; i <= 100; i++)
+        {
+            var name = lastNames[(i - 1) % lastNames.Length] + firstNames[(i - 1) % firstNames.Length];
+            var deptId = ((i - 1) % 5) + 1;
+            var email = $"user{i:D3}@example.com";
+            if (i > 1) values.Append(',');
+            values.Append($"('{name}', {deptId}, '{email}')");
+        }
+        var seedUsers = connection.CreateCommand();
+        seedUsers.CommandText = $"INSERT INTO Users (Name, DepartmentId, Email) VALUES {values};";
+        await seedUsers.ExecuteNonQueryAsync();
     }
 }

--- a/src/BlazorApp/Features/Demo/SelectStar/DTOs/SelectStarResponse.cs
+++ b/src/BlazorApp/Features/Demo/SelectStar/DTOs/SelectStarResponse.cs
@@ -1,31 +1,67 @@
 namespace BlazorApp.Features.Demo.DTOs;
 
+/// <summary>SELECT *デモの検索結果DTO</summary>
 public class SelectStarResponse
 {
+    /// <summary>クエリの実行時間（ミリ秒）</summary>
     public long ExecutionTimeMs { get; set; }
+
+    /// <summary>取得した件数</summary>
     public int RowCount { get; set; }
+
+    /// <summary>転送データのバイト数</summary>
     public long DataSize { get; set; }
+
+    /// <summary>転送量の表示用ラベル（例: "350.2 MB"）</summary>
     public string DataSizeLabel { get; set; } = "";
+
+    /// <summary>AWS転送費用の推計（$0.01/GB 基準）</summary>
     public double AwsCostEstimate { get; set; }
+
+    /// <summary>実行されたSQL文</summary>
     public string Sql { get; set; } = "";
+
+    /// <summary>結果メッセージ（転送量・AWS費用の説明）</summary>
     public string Message { get; set; } = "";
+
+    /// <summary>検索結果データ（先頭3件。全件返却はデータ量が大きすぎるため省略）</summary>
     public object Data { get; set; } = new();
 }
 
+/// <summary>SELECT *（全カラム）で取得したプロフィールDTO</summary>
 public class ProfileFull
 {
+    /// <summary>プロフィールID</summary>
     public int Id { get; set; }
+
+    /// <summary>ユーザー名</summary>
     public string Name { get; set; } = "";
+
+    /// <summary>メールアドレス</summary>
     public string Email { get; set; } = "";
+
+    /// <summary>自己紹介文（約10KB）</summary>
     public string Bio { get; set; } = "";
+
+    /// <summary>設定情報JSON（約5KB）</summary>
     public string Preferences { get; set; } = "";
+
+    /// <summary>アクティビティログJSON（約20KB）</summary>
     public string ActivityLog { get; set; } = "";
+
+    /// <summary>作成日時</summary>
     public string CreatedAt { get; set; } = "";
 }
 
+/// <summary>必要カラムのみ（Id, Name, Email）取得したプロフィールDTO</summary>
 public class ProfileSummary
 {
+    /// <summary>プロフィールID</summary>
     public int Id { get; set; }
+
+    /// <summary>ユーザー名</summary>
     public string Name { get; set; } = "";
+
+    /// <summary>メールアドレス</summary>
     public string Email { get; set; } = "";
 }

--- a/src/BlazorApp/Features/Demo/SelectStar/SelectStarController.cs
+++ b/src/BlazorApp/Features/Demo/SelectStar/SelectStarController.cs
@@ -3,24 +3,48 @@ using BlazorApp.Features.Demo.Services;
 
 namespace BlazorApp.Features.Demo.SelectStar;
 
+/// <summary>
+/// SELECT *問題デモ（全カラム取得 vs 必要カラムのみ取得）のコントローラー
+/// </summary>
+/// <remarks>
+/// <para><strong>設計書:</strong> .github/docs/features/select-star-demo/internal-design.md</para>
+/// <para><strong>責務:</strong> SELECT *（全カラム）と必要カラムのみの転送量・AWS費用の差を示すAPIエンドポイントを提供する</para>
+/// <para><strong>エンドポイント一覧:</strong></para>
+/// <list type="bullet">
+/// <item><description>GET  /Demo/SelectStar                      - デモ画面表示</description></item>
+/// <item><description>POST /api/demo/select-star/setup           - テストデータ生成（大容量テキスト含む）</description></item>
+/// <item><description>GET  /api/demo/select-star/all-columns     - SELECT *（全カラム）</description></item>
+/// <item><description>GET  /api/demo/select-star/specific-columns - SELECT Id,Name,Email（必要カラムのみ）</description></item>
+/// </list>
+/// </remarks>
 [Route("Demo")]
 public class SelectStarController : Controller
 {
     private readonly ISelectStarService _selectStarService;
     private readonly ILogger<SelectStarController> _logger;
 
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    /// <param name="selectStarService">SELECT *デモサービス</param>
+    /// <param name="logger">ロガー</param>
     public SelectStarController(ISelectStarService selectStarService, ILogger<SelectStarController> logger)
     {
         _selectStarService = selectStarService;
         _logger = logger;
     }
 
+    /// <summary>デモ画面を表示する</summary>
     [Route("SelectStar")]
     public IActionResult SelectStar()
     {
         return View("~/Features/Demo/SelectStar/Views/SelectStar.cshtml");
     }
 
+    /// <summary>
+    /// テストデータをセットアップする（Bio:10KB, Preferences:5KB, ActivityLog:20KB のデータを10,000件挿入）
+    /// </summary>
+    /// <returns>セットアップ結果（行数・処理時間）</returns>
     [HttpPost("/api/demo/select-star/setup")]
     public async Task<IActionResult> SelectStarSetup()
     {
@@ -36,6 +60,10 @@ public class SelectStarController : Controller
         }
     }
 
+    /// <summary>
+    /// SELECT * で全カラムを取得する（Bad実装）
+    /// </summary>
+    /// <returns>転送量・AWS費用推計・先頭3件のデータ</returns>
     [HttpGet("/api/demo/select-star/all-columns")]
     public async Task<IActionResult> SelectStarAllColumns()
     {
@@ -51,6 +79,10 @@ public class SelectStarController : Controller
         }
     }
 
+    /// <summary>
+    /// 必要カラムのみ（Id, Name, Email）を取得する（Good実装）
+    /// </summary>
+    /// <returns>転送量・AWS費用推計・先頭3件のデータ</returns>
     [HttpGet("/api/demo/select-star/specific-columns")]
     public async Task<IActionResult> SelectStarSpecificColumns()
     {

--- a/src/BlazorApp/Features/Demo/SelectStar/Services/ISelectStarService.cs
+++ b/src/BlazorApp/Features/Demo/SelectStar/Services/ISelectStarService.cs
@@ -2,9 +2,21 @@ using BlazorApp.Features.Demo.DTOs;
 
 namespace BlazorApp.Features.Demo.Services;
 
+/// <summary>
+/// SELECT *デモのサービスインターフェース
+/// </summary>
+/// <remarks>
+/// <para><strong>設計書:</strong> .github/docs/features/SelectStar/internal-design.md</para>
+/// <para><strong>責務:</strong> SELECT *（全カラム）と必要カラムのみ指定した場合の転送データ量・コストを比較する</para>
+/// </remarks>
 public interface ISelectStarService
 {
+    /// <summary>デモ用データ（デフォルト1万件）をセットアップする。各レコードにBio(10KB)・Preferences(5KB)・ActivityLog(20KB)を含む</summary>
     Task<SetupResponse> SetupAsync();
+
+    /// <summary>SELECT *で全カラムを取得する（大量のデータ転送が発生する）</summary>
     Task<SelectStarResponse> GetAllColumnsAsync();
+
+    /// <summary>必要なカラム（Id, Name, Email）のみ指定して取得する</summary>
     Task<SelectStarResponse> GetSpecificColumnsAsync();
 }

--- a/src/BlazorApp/Features/Demo/SelectStar/Services/SelectStarService.cs
+++ b/src/BlazorApp/Features/Demo/SelectStar/Services/SelectStarService.cs
@@ -6,14 +6,36 @@ using BlazorApp.Features.Demo.DTOs;
 
 namespace BlazorApp.Features.Demo.Services;
 
+/// <summary>
+/// SELECT *問題デモのサービス実装
+/// </summary>
+/// <remarks>
+/// <para><strong>設計書:</strong> .github/docs/features/select-star-demo/internal-design.md</para>
+/// <para><strong>責務:</strong> SELECT *（全カラム取得）と必要カラムのみ取得を比較し、転送量・AWS費用の差を示す</para>
+/// <para><strong>依存関係:</strong></para>
+/// <list type="bullet">
+/// <item><description>IConfiguration: 接続文字列（SelectStarDemo）取得</description></item>
+/// <item><description>ILogger: 実行時間・データ量のログ出力</description></item>
+/// </list>
+/// </remarks>
 public class SelectStarService : ISelectStarService
 {
     private readonly IConfiguration _configuration;
     private readonly ILogger<SelectStarService> _logger;
     private readonly int _totalRows;
 
+    /// <summary>AWS データ転送料金（$0.01/GB）。コスト推計に使用</summary>
     private const double AwsCostPerGb = 0.01;
 
+    /// <summary>INSERT時のバッチサイズ。SQLiteのパラメータ数上限（999）以内に収まる値</summary>
+    private const int BatchSize = 500;
+
+    /// <summary>
+    /// コンストラクタ
+    /// </summary>
+    /// <param name="configuration">接続文字列を含む設定</param>
+    /// <param name="logger">ロガー</param>
+    /// <param name="totalRows">セットアップ時に挿入する総行数（デフォルト: 10,000件）</param>
     public SelectStarService(IConfiguration configuration, ILogger<SelectStarService> logger, int totalRows = 10_000)
     {
         _configuration = configuration;
@@ -21,28 +43,25 @@ public class SelectStarService : ISelectStarService
         _totalRows = totalRows;
     }
 
-    private SqliteConnection GetConnection()
-    {
-        var connectionString = _configuration.GetConnectionString("SelectStarDemo");
-        return new SqliteConnection(connectionString);
-    }
-
-    private async Task EnsureTableCreatedAsync(SqliteConnection connection)
-    {
-        var cmd = connection.CreateCommand();
-        cmd.CommandText = @"
-            CREATE TABLE IF NOT EXISTS Profiles (
-                Id          INTEGER PRIMARY KEY AUTOINCREMENT,
-                Name        TEXT    NOT NULL,
-                Email       TEXT    NOT NULL,
-                Bio         TEXT,
-                Preferences TEXT,
-                ActivityLog TEXT,
-                CreatedAt   TEXT    NOT NULL DEFAULT (datetime('now'))
-            );";
-        await cmd.ExecuteNonQueryAsync();
-    }
-
+    /// <summary>
+    /// テストデータのセットアップ（Profilesテーブル作成 + 大容量データ挿入）
+    /// </summary>
+    /// <returns>セットアップ結果（行数・処理時間）</returns>
+    /// <remarks>
+    /// <para><strong>アルゴリズム:</strong></para>
+    /// <list type="number">
+    /// <item><description>Profilesテーブルが未作成の場合に作成</description></item>
+    /// <item><description>既存データがある場合はスキップして早期リターン</description></item>
+    /// <item><description>Bio(10KB) / Preferences(5KB) / ActivityLog(20KB) の大容量テキストを生成</description></item>
+    /// <item><description><see cref="BatchSize"/>件ずつバッチINSERTをトランザクション内で実行</description></item>
+    /// </list>
+    /// <para><strong>SQL文:</strong></para>
+    /// <code>
+    /// INSERT INTO Profiles (Name, Email, Bio, Preferences, ActivityLog)
+    /// VALUES (...), (...), ...   -- BatchSize件ずつ
+    /// </code>
+    /// <para><strong>期待実行時間:</strong> 約5〜15秒（10,000件・大容量テキスト含む）</para>
+    /// </remarks>
     public async Task<SetupResponse> SetupAsync()
     {
         var sw = Stopwatch.StartNew();
@@ -51,9 +70,7 @@ public class SelectStarService : ISelectStarService
         await connection.OpenAsync();
         await EnsureTableCreatedAsync(connection);
 
-        var countCmd = connection.CreateCommand();
-        countCmd.CommandText = "SELECT COUNT(*) FROM Profiles";
-        var existing = Convert.ToInt32(await countCmd.ExecuteScalarAsync());
+        var existing = await CountExistingRowsAsync(connection);
         if (existing > 0)
         {
             sw.Stop();
@@ -66,34 +83,7 @@ public class SelectStarService : ISelectStarService
             };
         }
 
-        // 大容量テキストの生成
-        var bio = string.Concat(Enumerable.Repeat("私は東京都出身のソフトウェアエンジニアです。Web開発を得意としており、特にC#と.NETの経験が豊富です。", 100));
-        var preferences = string.Concat(Enumerable.Repeat("{\"theme\":\"dark\",\"language\":\"ja\",\"notifications\":{\"email\":true,\"push\":true}}", 62));
-        var activityLog = string.Concat(Enumerable.Repeat("[{\"timestamp\":\"2024-01-01T00:00:00Z\",\"action\":\"login\",\"ip\":\"192.168.1.1\"}]", 200));
-
-        var lastNames = new[] { "田中", "鈴木", "佐藤", "高橋", "伊藤", "渡辺", "山本", "中村", "小林", "加藤" };
-        var firstNames = new[] { "太郎", "花子", "次郎", "美咲", "健一", "恵子", "大輔", "裕子", "隆", "由美" };
-
-        const int batchSize = 500;
-        using var transaction = connection.BeginTransaction();
-        for (int batch = 0; batch < _totalRows / batchSize; batch++)
-        {
-            var values = new StringBuilder();
-            for (int i = 0; i < batchSize; i++)
-            {
-                var rowNum = batch * batchSize + i + 1;
-                var name = lastNames[rowNum % lastNames.Length] + firstNames[rowNum % firstNames.Length];
-                if (i > 0) values.Append(',');
-                values.Append($"('{name}', 'user{rowNum}@example.com', @bio, @pref, @log)");
-            }
-            var insertCmd = connection.CreateCommand();
-            insertCmd.CommandText = $"INSERT INTO Profiles (Name, Email, Bio, Preferences, ActivityLog) VALUES {values}";
-            insertCmd.Parameters.AddWithValue("@bio", bio);
-            insertCmd.Parameters.AddWithValue("@pref", preferences);
-            insertCmd.Parameters.AddWithValue("@log", activityLog);
-            await insertCmd.ExecuteNonQueryAsync();
-        }
-        transaction.Commit();
+        await InsertBatchDataAsync(connection);
 
         sw.Stop();
         _logger.LogInformation("SelectStar setup completed: {RowCount} rows, {ExecutionTimeMs}ms", _totalRows, sw.ElapsedMilliseconds);
@@ -107,6 +97,15 @@ public class SelectStarService : ISelectStarService
         };
     }
 
+    /// <summary>
+    /// SELECT * による全カラム取得（Bad実装）
+    /// </summary>
+    /// <returns>検索結果（転送量・AWS費用推計・先頭3件のデータ）</returns>
+    /// <remarks>
+    /// <para><strong>SQL文:</strong></para>
+    /// <code>SELECT * FROM Profiles</code>
+    /// <para><strong>期待転送量:</strong> 約350MB（Bio/Preferences/ActivityLogを含む全カラム）</para>
+    /// </remarks>
     public async Task<SelectStarResponse> GetAllColumnsAsync()
     {
         var sw = Stopwatch.StartNew();
@@ -151,6 +150,15 @@ public class SelectStarService : ISelectStarService
         };
     }
 
+    /// <summary>
+    /// 必要カラムのみ取得（Good実装）
+    /// </summary>
+    /// <returns>検索結果（転送量・AWS費用推計・先頭3件のデータ）</returns>
+    /// <remarks>
+    /// <para><strong>SQL文:</strong></para>
+    /// <code>SELECT Id, Name, Email FROM Profiles</code>
+    /// <para><strong>期待転送量:</strong> 約1MB未満（必要最小限のカラムのみ）</para>
+    /// </remarks>
     public async Task<SelectStarResponse> GetSpecificColumnsAsync()
     {
         var sw = Stopwatch.StartNew();
@@ -191,6 +199,94 @@ public class SelectStarService : ISelectStarService
         };
     }
 
+    /// <summary>接続文字列からSQLite接続を生成する</summary>
+    private SqliteConnection GetConnection()
+    {
+        var connectionString = _configuration.GetConnectionString("SelectStarDemo");
+        return new SqliteConnection(connectionString);
+    }
+
+    /// <summary>
+    /// Profilesテーブルが存在しない場合に作成する
+    /// </summary>
+    /// <remarks>
+    /// <para><strong>SQL文:</strong></para>
+    /// <code>
+    /// CREATE TABLE IF NOT EXISTS Profiles (
+    ///     Id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ///     Name TEXT NOT NULL, Email TEXT NOT NULL,
+    ///     Bio TEXT, Preferences TEXT, ActivityLog TEXT,
+    ///     CreatedAt TEXT NOT NULL DEFAULT (datetime('now'))
+    /// );
+    /// </code>
+    /// </remarks>
+    private static async Task EnsureTableCreatedAsync(SqliteConnection connection)
+    {
+        var cmd = connection.CreateCommand();
+        cmd.CommandText = @"
+            CREATE TABLE IF NOT EXISTS Profiles (
+                Id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                Name        TEXT    NOT NULL,
+                Email       TEXT    NOT NULL,
+                Bio         TEXT,
+                Preferences TEXT,
+                ActivityLog TEXT,
+                CreatedAt   TEXT    NOT NULL DEFAULT (datetime('now'))
+            );";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>Profilesテーブルの既存行数を返す</summary>
+    private static async Task<int> CountExistingRowsAsync(SqliteConnection connection)
+    {
+        var countCmd = connection.CreateCommand();
+        countCmd.CommandText = "SELECT COUNT(*) FROM Profiles";
+        return Convert.ToInt32(await countCmd.ExecuteScalarAsync());
+    }
+
+    /// <summary>
+    /// <see cref="BatchSize"/>件ずつバッチINSERTでProfilesデータを挿入する
+    /// </summary>
+    /// <remarks>
+    /// トランザクションをまとめることでSQLiteのfsync呼び出しを削減し、挿入速度を向上させる。
+    /// Bio/Preferences/ActivityLogはパラメータバインドで渡し、SQLインジェクションを防ぐ。
+    /// </remarks>
+    private async Task InsertBatchDataAsync(SqliteConnection connection)
+    {
+        // SELECT *問題を際立たせるための大容量テキスト（カラムごとの想定サイズ: Bio≈10KB, Preferences≈5KB, ActivityLog≈20KB）
+        var bio = string.Concat(Enumerable.Repeat("私は東京都出身のソフトウェアエンジニアです。Web開発を得意としており、特にC#と.NETの経験が豊富です。", 100));
+        var preferences = string.Concat(Enumerable.Repeat("{\"theme\":\"dark\",\"language\":\"ja\",\"notifications\":{\"email\":true,\"push\":true}}", 62));
+        var activityLog = string.Concat(Enumerable.Repeat("[{\"timestamp\":\"2024-01-01T00:00:00Z\",\"action\":\"login\",\"ip\":\"192.168.1.1\"}]", 200));
+
+        var lastNames = new[] { "田中", "鈴木", "佐藤", "高橋", "伊藤", "渡辺", "山本", "中村", "小林", "加藤" };
+        var firstNames = new[] { "太郎", "花子", "次郎", "美咲", "健一", "恵子", "大輔", "裕子", "隆", "由美" };
+
+        using var transaction = connection.BeginTransaction();
+        for (int batch = 0; batch < _totalRows / BatchSize; batch++)
+        {
+            var values = new StringBuilder();
+            for (int i = 0; i < BatchSize; i++)
+            {
+                var rowNum = batch * BatchSize + i + 1;
+                var name = lastNames[rowNum % lastNames.Length] + firstNames[rowNum % firstNames.Length];
+                if (i > 0) values.Append(',');
+                values.Append($"('{name}', 'user{rowNum}@example.com', @bio, @pref, @log)");
+            }
+            var insertCmd = connection.CreateCommand();
+            insertCmd.CommandText = $"INSERT INTO Profiles (Name, Email, Bio, Preferences, ActivityLog) VALUES {values}";
+            insertCmd.Parameters.AddWithValue("@bio", bio);
+            insertCmd.Parameters.AddWithValue("@pref", preferences);
+            insertCmd.Parameters.AddWithValue("@log", activityLog);
+            await insertCmd.ExecuteNonQueryAsync();
+        }
+        transaction.Commit();
+    }
+
+    /// <summary>
+    /// オブジェクトをJSONシリアライズしてバイト数・ラベル・AWS転送費用を計算する
+    /// </summary>
+    /// <param name="data">計算対象のオブジェクト</param>
+    /// <returns>(バイト数, 表示用ラベル, AWSコスト推計)</returns>
     private static (long bytes, string label, double awsCost) CalcDataSize(object data)
     {
         var json = JsonSerializer.Serialize(data);


### PR DESCRIPTION
## 概要

closes #89

Demoサービス群（FullScan/LikeSearch/NPlus/SelectStar）のコードに対して、AIが規約を読まずにコードを生成していたことによる認知コスト増大を解消するリファクタリングを実施。

## 変更内容

### XMLドキュメントコメント追加
- 全Service実装クラス・インターフェース・Controller・DTOにXMLコメントを追加
- 各メソッドにSQL文・アルゴリズム・期待実行時間を記載

### 定数化
- `BatchSize = 500`（FullScanService/LikeSearchService/SelectStarService）
- `AwsCostPerGb = 0.01`（SelectStarService）

### メソッド抽出
- `CountExistingRowsAsync()` — 既存行数カウントを抽出
- `InsertBatchDataAsync()` — バッチINSERT処理を抽出
- `EnsureDatabaseInitializedAsync()` / `EnsureTableCreatedAsync()` を `static` に変更

### その他
- `claude.md` に `copilot-instructions.md` 参照の強制化を追加

## テスト

- `dotnet build` エラー0件確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)