### PR TITLE
fix: FullScanServiceTests のテスト間 DB 汚染修正

### DIFF
--- a/BlazorApp.Tests/Features/Demo/FullScanServiceTests.cs
+++ b/BlazorApp.Tests/Features/Demo/FullScanServiceTests.cs
@@ -19,7 +19,7 @@ public class FullScanServiceTests : IDisposable
 
     public FullScanServiceTests()
     {
-        _connectionString = "Data Source=FullScanTest;Mode=Memory;Cache=Shared";
+        _connectionString = $"Data Source=FullScanTest_{Guid.NewGuid():N};Mode=Memory;Cache=Shared";
 
         _sharedConnection = new SqliteConnection(_connectionString);
         _sharedConnection.Open();


### PR DESCRIPTION
## Summary
- FullScanServiceTests が共有インメモリ SQLite DB 名 FullScanTest を固定値で使っていたため、SQLite のコネクションプールが前テストのデータを次テストまで保持し SetupAsync 正常系テストが flaky になっていた
- 各テストインスタンスで Guid を使った一意な DB 名を生成することでテスト間の状態汚染を排除した

## Test plan
- dotnet test --filter FullScan で 9/9 合格を確認済み
- CI の Run Tests が green になることを確認

Generated with Claude Code